### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,16 +7,16 @@
 
 #Methods / functions
 
-LCDInit KEYWORD2
-LCDgotoXY KEYWORD2
-LCDClear KEYWORD2
-LCDString KEYWORD2
-LCDsetContrast KEYWORD2
-LCDenableSleep KEYWORD2
-LCDdisableSleep KEYWORD2
-LCDClearBlock  KEYWORD2
-LCDCharacter   KEYWORD2
-LCDWrite       KEYWORD2
+LCDInit	KEYWORD2
+LCDgotoXY	KEYWORD2
+LCDClear	KEYWORD2
+LCDString	KEYWORD2
+LCDsetContrast	KEYWORD2
+LCDenableSleep	KEYWORD2
+LCDdisableSleep	KEYWORD2
+LCDClearBlock	KEYWORD2
+LCDCharacter	KEYWORD2
+LCDWrite	KEYWORD2
 
 # Constants
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords